### PR TITLE
Add support for transforming output. Add Steam transform.

### DIFF
--- a/KeeOtp2/Forms/OtpInformation.Designer.cs
+++ b/KeeOtp2/Forms/OtpInformation.Designer.cs
@@ -49,6 +49,8 @@
             this.groupboxEncoding = new System.Windows.Forms.GroupBox();
             this.radioButtonUtf8 = new System.Windows.Forms.RadioButton();
             this.groupboxSize = new System.Windows.Forms.GroupBox();
+            this.textBoxCustomDigits = new System.Windows.Forms.TextBox();
+            this.radioButtonCustomDigits = new System.Windows.Forms.RadioButton();
             this.groupboxInfo = new System.Windows.Forms.GroupBox();
             this.checkboxOldKeeOtp = new System.Windows.Forms.CheckBox();
             this.linkLabelLoadUriScanQR = new System.Windows.Forms.LinkLabel();
@@ -56,8 +58,9 @@
             this.timerUpdateTotp = new System.Windows.Forms.Timer(this.components);
             this.linkLabelMigrate = new System.Windows.Forms.LinkLabel();
             this.labelStatus = new System.Windows.Forms.Label();
-            this.radioButtonCustomDigits = new System.Windows.Forms.RadioButton();
-            this.textBoxCustomDigits = new System.Windows.Forms.TextBox();
+            this.groupBoxTransform = new System.Windows.Forms.GroupBox();
+            this.radioButtonDigits = new System.Windows.Forms.RadioButton();
+            this.radioButtonSteam = new System.Windows.Forms.RadioButton();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxBanner)).BeginInit();
             this.groupboxHashAlgorithm.SuspendLayout();
             this.groupboxTimeStep.SuspendLayout();
@@ -65,13 +68,14 @@
             this.groupboxSize.SuspendLayout();
             this.groupboxInfo.SuspendLayout();
             this.groupBoxKey.SuspendLayout();
+            this.groupBoxTransform.SuspendLayout();
             this.SuspendLayout();
             // 
             // textBoxKey
             // 
             this.textBoxKey.Location = new System.Drawing.Point(6, 19);
             this.textBoxKey.Name = "textBoxKey";
-            this.textBoxKey.Size = new System.Drawing.Size(330, 20);
+            this.textBoxKey.Size = new System.Drawing.Size(446, 20);
             this.textBoxKey.TabIndex = 0;
             this.textBoxKey.TextChanged += new System.EventHandler(this.textBoxKey_TextChanged);
             this.textBoxKey.KeyDown += new System.Windows.Forms.KeyEventHandler(this.textBoxKey_KeyDown);
@@ -80,7 +84,7 @@
             // 
             this.textBoxStep.Location = new System.Drawing.Point(118, 13);
             this.textBoxStep.Name = "textBoxStep";
-            this.textBoxStep.Size = new System.Drawing.Size(23, 20);
+            this.textBoxStep.Size = new System.Drawing.Size(20, 20);
             this.textBoxStep.TabIndex = 1;
             // 
             // radioButtonSix
@@ -118,7 +122,7 @@
             // 
             this.buttonOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonOk.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.buttonOk.Location = new System.Drawing.Point(201, 312);
+            this.buttonOk.Location = new System.Drawing.Point(317, 312);
             this.buttonOk.Name = "buttonOk";
             this.buttonOk.Size = new System.Drawing.Size(75, 23);
             this.buttonOk.TabIndex = 7;
@@ -129,7 +133,7 @@
             // 
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(282, 312);
+            this.buttonCancel.Location = new System.Drawing.Point(398, 312);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
             this.buttonCancel.TabIndex = 8;
@@ -173,7 +177,7 @@
             this.pictureBoxBanner.Dock = System.Windows.Forms.DockStyle.Top;
             this.pictureBoxBanner.Location = new System.Drawing.Point(0, 0);
             this.pictureBoxBanner.Name = "pictureBoxBanner";
-            this.pictureBoxBanner.Size = new System.Drawing.Size(374, 58);
+            this.pictureBoxBanner.Size = new System.Drawing.Size(490, 58);
             this.pictureBoxBanner.TabIndex = 12;
             this.pictureBoxBanner.TabStop = false;
             // 
@@ -241,7 +245,7 @@
             this.groupboxTimeStep.Controls.Add(this.textBoxStep);
             this.groupboxTimeStep.Location = new System.Drawing.Point(15, 143);
             this.groupboxTimeStep.Name = "groupboxTimeStep";
-            this.groupboxTimeStep.Size = new System.Drawing.Size(168, 41);
+            this.groupboxTimeStep.Size = new System.Drawing.Size(226, 41);
             this.groupboxTimeStep.TabIndex = 17;
             this.groupboxTimeStep.TabStop = false;
             this.groupboxTimeStep.Text = "Time Step";
@@ -284,13 +288,32 @@
             this.groupboxSize.TabStop = false;
             this.groupboxSize.Text = "Size";
             // 
+            // textBoxCustomDigits
+            // 
+            this.textBoxCustomDigits.Location = new System.Drawing.Point(70, 64);
+            this.textBoxCustomDigits.Name = "textBoxCustomDigits";
+            this.textBoxCustomDigits.Size = new System.Drawing.Size(34, 20);
+            this.textBoxCustomDigits.TabIndex = 26;
+            // 
+            // radioButtonCustomDigits
+            // 
+            this.radioButtonCustomDigits.AutoSize = true;
+            this.radioButtonCustomDigits.Location = new System.Drawing.Point(6, 65);
+            this.radioButtonCustomDigits.Name = "radioButtonCustomDigits";
+            this.radioButtonCustomDigits.Size = new System.Drawing.Size(63, 17);
+            this.radioButtonCustomDigits.TabIndex = 25;
+            this.radioButtonCustomDigits.TabStop = true;
+            this.radioButtonCustomDigits.Text = "Custom:";
+            this.radioButtonCustomDigits.UseVisualStyleBackColor = true;
+            this.radioButtonCustomDigits.CheckedChanged += new System.EventHandler(this.radioButtonCustomDigits_CheckedChanged);
+            // 
             // groupboxInfo
             // 
             this.groupboxInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.groupboxInfo.Controls.Add(this.checkboxOldKeeOtp);
-            this.groupboxInfo.Location = new System.Drawing.Point(189, 143);
+            this.groupboxInfo.Location = new System.Drawing.Point(247, 143);
             this.groupboxInfo.Name = "groupboxInfo";
-            this.groupboxInfo.Size = new System.Drawing.Size(168, 41);
+            this.groupboxInfo.Size = new System.Drawing.Size(226, 41);
             this.groupboxInfo.TabIndex = 5;
             this.groupboxInfo.TabStop = false;
             this.groupboxInfo.Text = "KeeOtp1 String (Deprecated)";
@@ -308,7 +331,7 @@
             // linkLabelLoadUriScanQR
             // 
             this.linkLabelLoadUriScanQR.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.linkLabelLoadUriScanQR.Location = new System.Drawing.Point(259, 0);
+            this.linkLabelLoadUriScanQR.Location = new System.Drawing.Point(375, 0);
             this.linkLabelLoadUriScanQR.Name = "linkLabelLoadUriScanQR";
             this.linkLabelLoadUriScanQR.Size = new System.Drawing.Size(80, 13);
             this.linkLabelLoadUriScanQR.TabIndex = 20;
@@ -323,7 +346,7 @@
             this.groupBoxKey.Controls.Add(this.linkLabelLoadUriScanQR);
             this.groupBoxKey.Location = new System.Drawing.Point(15, 64);
             this.groupBoxKey.Name = "groupBoxKey";
-            this.groupBoxKey.Size = new System.Drawing.Size(342, 49);
+            this.groupBoxKey.Size = new System.Drawing.Size(458, 49);
             this.groupBoxKey.TabIndex = 22;
             this.groupBoxKey.TabStop = false;
             this.groupBoxKey.Text = "Key or Uri (otpauth://):";
@@ -337,7 +360,7 @@
             // 
             this.linkLabelMigrate.AutoSize = true;
             this.linkLabelMigrate.Enabled = false;
-            this.linkLabelMigrate.Location = new System.Drawing.Point(263, 121);
+            this.linkLabelMigrate.Location = new System.Drawing.Point(379, 121);
             this.linkLabelMigrate.Name = "linkLabelMigrate";
             this.linkLabelMigrate.Size = new System.Drawing.Size(91, 13);
             this.linkLabelMigrate.TabIndex = 23;
@@ -357,30 +380,46 @@
             this.labelStatus.TabIndex = 24;
             this.labelStatus.Text = "(*Hover for more information)";
             // 
-            // radioButtonCustomDigits
+            // groupBoxTransform
             // 
-            this.radioButtonCustomDigits.AutoSize = true;
-            this.radioButtonCustomDigits.Location = new System.Drawing.Point(6, 65);
-            this.radioButtonCustomDigits.Name = "radioButtonCustomDigits";
-            this.radioButtonCustomDigits.Size = new System.Drawing.Size(63, 17);
-            this.radioButtonCustomDigits.TabIndex = 25;
-            this.radioButtonCustomDigits.TabStop = true;
-            this.radioButtonCustomDigits.Text = "Custom:";
-            this.radioButtonCustomDigits.UseVisualStyleBackColor = true;
-            this.radioButtonCustomDigits.CheckedChanged += new System.EventHandler(this.radioButtonCustomDigits_CheckedChanged);
+            this.groupBoxTransform.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.groupBoxTransform.Controls.Add(this.radioButtonDigits);
+            this.groupBoxTransform.Controls.Add(this.radioButtonSteam);
+            this.groupBoxTransform.Location = new System.Drawing.Point(363, 190);
+            this.groupBoxTransform.Name = "groupBoxTransform";
+            this.groupBoxTransform.Size = new System.Drawing.Size(110, 113);
+            this.groupBoxTransform.TabIndex = 18;
+            this.groupBoxTransform.TabStop = false;
+            this.groupBoxTransform.Text = "Transform";
             // 
-            // textBoxCustomDigits
+            // radioButtonDigits
             // 
-            this.textBoxCustomDigits.Location = new System.Drawing.Point(70, 64);
-            this.textBoxCustomDigits.Name = "textBoxCustomDigits";
-            this.textBoxCustomDigits.Size = new System.Drawing.Size(34, 20);
-            this.textBoxCustomDigits.TabIndex = 26;
+            this.radioButtonDigits.AutoSize = true;
+            this.radioButtonDigits.Checked = true;
+            this.radioButtonDigits.Location = new System.Drawing.Point(6, 19);
+            this.radioButtonDigits.Name = "radioButtonDigits";
+            this.radioButtonDigits.Size = new System.Drawing.Size(51, 17);
+            this.radioButtonDigits.TabIndex = 16;
+            this.radioButtonDigits.TabStop = true;
+            this.radioButtonDigits.Text = "Digits";
+            this.radioButtonDigits.UseVisualStyleBackColor = true;
+            // 
+            // radioButtonSteam
+            // 
+            this.radioButtonSteam.AutoSize = true;
+            this.radioButtonSteam.Location = new System.Drawing.Point(6, 42);
+            this.radioButtonSteam.Name = "radioButtonSteam";
+            this.radioButtonSteam.Size = new System.Drawing.Size(55, 17);
+            this.radioButtonSteam.TabIndex = 14;
+            this.radioButtonSteam.Text = "Steam";
+            this.radioButtonSteam.UseVisualStyleBackColor = true;
             // 
             // OtpInformation
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(374, 350);
+            this.ClientSize = new System.Drawing.Size(490, 350);
+            this.Controls.Add(this.groupBoxTransform);
             this.Controls.Add(this.labelStatus);
             this.Controls.Add(this.linkLabelMigrate);
             this.Controls.Add(this.groupBoxKey);
@@ -413,6 +452,8 @@
             this.groupboxInfo.PerformLayout();
             this.groupBoxKey.ResumeLayout(false);
             this.groupBoxKey.PerformLayout();
+            this.groupBoxTransform.ResumeLayout(false);
+            this.groupBoxTransform.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -449,5 +490,8 @@
         private System.Windows.Forms.Label labelStatus;
         private System.Windows.Forms.TextBox textBoxCustomDigits;
         private System.Windows.Forms.RadioButton radioButtonCustomDigits;
+        private System.Windows.Forms.GroupBox groupBoxTransform;
+        private System.Windows.Forms.RadioButton radioButtonDigits;
+        private System.Windows.Forms.RadioButton radioButtonSteam;
     }
 }

--- a/KeeOtp2/Forms/OtpInformation.cs
+++ b/KeeOtp2/Forms/OtpInformation.cs
@@ -54,6 +54,8 @@ namespace KeeOtp2
             radioButtonSix.Text = KeeOtp2Statics.SixDigits;
             radioButtonEight.Text = KeeOtp2Statics.EightDigits;
             radioButtonCustomDigits.Text = KeeOtp2Statics.Custom + KeeOtp2Statics.SelectorChar;
+            radioButtonDigits.Text = KeeOtp2Statics.Digits;
+            radioButtonSteam.Text = KeeOtp2Statics.Steam;
             groupboxHashAlgorithm.Text = KeeOtp2Statics.HashAlgorithm;
             radioButtonSha1.Text = KeeOtp2Statics.Sha1;
             radioButtonSha256.Text = KeeOtp2Statics.Sha256;
@@ -152,13 +154,17 @@ namespace KeeOtp2
                         data.Digits = digits;
                     }
 
-
                     if (this.radioButtonSha1.Checked)
                         data.Algorithm = OtpHashMode.Sha1;
                     else if (this.radioButtonSha256.Checked)
                         data.Algorithm = OtpHashMode.Sha256;
                     else if (this.radioButtonSha512.Checked)
                         data.Algorithm = OtpHashMode.Sha512;
+
+                    if (this.radioButtonDigits.Checked)
+                        data.Transform = OtpTransformType.Digits;
+                    else if (this.radioButtonSteam.Checked)
+                        data.Transform = OtpTransformType.Steam;
                 }
 
                 data.SetPlainSecret(secret);
@@ -316,7 +322,8 @@ namespace KeeOtp2
 
                 if (this.Data.Period != 30 || this.Data.KeeOtp1Mode ||
                     this.Data.Encoding != OtpSecretEncoding.Base32 ||
-                    this.Data.Digits != 6 || this.Data.Algorithm != OtpHashMode.Sha1)
+                    this.Data.Digits != 6 || this.Data.Algorithm != OtpHashMode.Sha1 ||
+                    this.Data.Transform != OtpTransformType.Digits)
                 {
                     this.checkBoxCustomSettings.Checked = true;
                 }
@@ -404,6 +411,17 @@ namespace KeeOtp2
                     this.radioButtonSha256.Checked = false;
                     this.radioButtonSha512.Checked = false;
                 }
+
+                if (this.Data.Transform == OtpTransformType.Steam)
+                {
+                    this.radioButtonDigits.Checked = false;
+                    this.radioButtonSteam.Checked = true;
+                }
+                else // default transform
+                {
+                    this.radioButtonDigits.Checked = true;
+                    this.radioButtonSteam.Checked = false;
+                }
             }
             else
             {
@@ -416,11 +434,15 @@ namespace KeeOtp2
                 this.radioButtonEight.Checked = false;
                 this.radioButtonCustomDigits.Checked = false;
                 this.textBoxCustomDigits.ReadOnly = true;
+                this.radioButtonSteam.Checked = false;
 
                 this.radioButtonBase32.Checked = true;
                 this.radioButtonBase64.Checked = false;
                 this.radioButtonHex.Checked = false;
                 this.radioButtonUtf8.Checked = false;
+
+                this.radioButtonDigits.Checked = true;
+                this.radioButtonSteam.Checked = false;
             }
 
             SetCustomSettingsState(false);
@@ -444,6 +466,8 @@ namespace KeeOtp2
                 this.radioButtonSha1.Enabled =
                 this.radioButtonSha256.Enabled =
                 this.radioButtonSha512.Enabled =
+                this.radioButtonDigits.Enabled =
+                this.radioButtonSteam.Enabled =
                 this.checkboxOldKeeOtp.Enabled = useCustom;
         }
 
@@ -491,8 +515,8 @@ namespace KeeOtp2
                 try
                 {
                     OtpAuthData data = readData();
-                    Totp totp = OtpAuthUtils.getTotp(data);
-                    groupBoxKey.Text = String.Format(KeeOtp2Statics.OtpInformationKeyUriPreview, totp.ComputeTotp(OtpTime.getTime()), totp.RemainingSeconds());
+                    OtpTotp totp = OtpAuthUtils.getTotp(data);
+                    groupBoxKey.Text = String.Format(KeeOtp2Statics.OtpInformationKeyUriPreview, totp.getTotpString(OtpTime.getTime()), totp.getRemainingSeconds());
                 }
                 catch
                 {

--- a/KeeOtp2/Forms/ShowOneTimePasswords.cs
+++ b/KeeOtp2/Forms/ShowOneTimePasswords.cs
@@ -12,7 +12,7 @@ namespace KeeOtp2
     {
         private readonly KeePassLib.PwEntry entry;
         private readonly IPluginHost host ;
-        private Totp totp;
+        private OtpTotp totp;
         private string lastCode;
         private int lastRemainingTime;
 
@@ -61,19 +61,19 @@ namespace KeeOtp2
             var totp = this.totp;
             if (totp != null)
             {
-                string code = totp.ComputeTotp(OtpTime.getTime()).ToString();
-                string nextCode = totp.ComputeTotp(OtpTime.getTime().AddSeconds(data.Period)).ToString();
-                var remaining = totp.RemainingSeconds();
+                string code = totp.getTotpString(OtpTime.getTime());
+                string nextCode = totp.getTotpString(OtpTime.getTime().AddSeconds(data.Period));
+                var remaining = totp.getRemainingSeconds();
 
                 if (code != lastCode)
                 {
                     lastCode = code;
-                    this.labelOtp.Text = code.ToString().PadLeft(this.data.Digits, '0');
+                    this.labelOtp.Text = code;
                 }
                 if (remaining != lastRemainingTime)
                 {
                     lastRemainingTime = remaining;
-                    this.groupboxTotp.Text = String.Format(KeeOtp2Statics.ShowOtpNextRemaining, remaining.ToString().PadLeft(2, '0'), nextCode.ToString().PadLeft(this.data.Digits, '0'));
+                    this.groupboxTotp.Text = String.Format(KeeOtp2Statics.ShowOtpNextRemaining, remaining.ToString().PadLeft(2, '0'), nextCode);
                 }
             }
             else
@@ -112,7 +112,7 @@ namespace KeeOtp2
             this.lastCode = "";
             this.lastRemainingTime = 0;
 
-            this.totp = new Totp(data.Key, data.Period, data.Algorithm, data.Digits, null);
+            this.totp = OtpAuthUtils.getTotp(data);
             this.timerUpdateTotp.Enabled = true;
         }
 
@@ -149,7 +149,7 @@ namespace KeeOtp2
 
         private void labelOtp_Click(object sender, EventArgs e)
         {
-            if (ClipboardUtil.CopyAndMinimize(new ProtectedString(true, this.totp.ComputeTotp(OtpTime.getTime()).ToString().PadLeft(data.Digits, '0')), true, this.host.MainWindow, entry, this.host.Database))
+            if (ClipboardUtil.CopyAndMinimize(new ProtectedString(true, this.totp.getTotpString(OtpTime.getTime())), true, this.host.MainWindow, entry, this.host.Database))
                 this.host.MainWindow.StartClipboardCountdown();
             this.Close();
         }
@@ -171,7 +171,7 @@ namespace KeeOtp2
 
         private void buttonCopyTotp_Click(object sender, EventArgs e)
         {
-            if (ClipboardUtil.CopyAndMinimize(new ProtectedString(true, this.totp.ComputeTotp(OtpTime.getTime()).ToString().PadLeft(data.Digits, '0')), true, this.host.MainWindow, entry, this.host.Database))
+            if (ClipboardUtil.CopyAndMinimize(new ProtectedString(true, this.totp.getTotpString(OtpTime.getTime())), true, this.host.MainWindow, entry, this.host.Database))
                 this.host.MainWindow.StartClipboardCountdown();
             this.Close();
         }

--- a/KeeOtp2/KeeOtp2.csproj
+++ b/KeeOtp2/KeeOtp2.csproj
@@ -106,8 +106,10 @@
     <Compile Include="OtpAuthData.cs" />
     <Compile Include="OtpAuthExceptions.cs" />
     <Compile Include="OtpAuthUtils.cs" />
+    <Compile Include="OtpTransform.cs" />
     <Compile Include="OtpSecretEncoding.cs" />
     <Compile Include="OtpTime.cs" />
+    <Compile Include="OtpTotp.cs" />
     <Compile Include="OtpType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/KeeOtp2/KeeOtp2Statics.cs
+++ b/KeeOtp2/KeeOtp2Statics.cs
@@ -51,6 +51,8 @@ namespace KeeOtp2
         public static readonly string Information = "Information";
         public static readonly string Actions = "Actions";
         public static readonly string Custom = "Custom";
+        public static readonly string Digits = "Digits";
+        public static readonly string Steam = "Steam";
 
         public static readonly string About = "About";
         public static readonly string AboutSubline = "KeeOtp2 Plugin.";

--- a/KeeOtp2/OtpAuthData.cs
+++ b/KeeOtp2/OtpAuthData.cs
@@ -12,6 +12,7 @@ namespace KeeOtp2
         public Key Key { get; set; }
         public OtpType Type { get; set; }
         public OtpSecretEncoding Encoding { get; set; }
+        public OtpTransformType Transform { get; set; }
 
         public OtpHashMode Algorithm { get; set; }
 
@@ -29,6 +30,7 @@ namespace KeeOtp2
             this.Type = OtpType.Totp;
             this.Encoding = OtpSecretEncoding.Base32;
             this.Algorithm = OtpHashMode.Sha1;
+            this.Transform = OtpTransformType.Digits;
 
             this.Counter = 25;
             this.Period = 30;

--- a/KeeOtp2/OtpTotp.cs
+++ b/KeeOtp2/OtpTotp.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Text;
+using OtpSharp;
+
+namespace KeeOtp2
+{
+    public class OtpTotp
+    {
+        private readonly OtpTransform transform;
+        private readonly Totp totp;
+        private readonly OtpAuthData data;
+
+        public OtpTotp(OtpAuthData data)
+        {
+            this.data = data;
+            transform = OtpTransform.getTransform(data.Transform);
+            totp = transform.getCustomTotp(data);
+        }
+
+        public int getRemainingSeconds()
+        {
+            return totp.RemainingSeconds();
+        }
+
+        public string getTotpString()
+        {
+            return getTotpString(DateTime.Now);
+        }
+
+        public string getTotpString(DateTime timestamp)
+        {
+            return transform.transformTotp(totp, timestamp);
+        }
+    }
+}

--- a/KeeOtp2/OtpTransform.cs
+++ b/KeeOtp2/OtpTransform.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Text;
+using OtpSharp;
+
+namespace KeeOtp2
+{
+    public enum OtpTransformType
+    {
+        Digits,
+        Steam
+    }
+
+    public abstract class OtpTransform
+    {
+        public abstract Totp getCustomTotp(OtpAuthData data);
+
+        public abstract string transformTotp(Totp totp, DateTime timestamp);
+
+        public static OtpTransform getTransform(OtpTransformType transform)
+        {
+            switch (transform)
+            {
+                case OtpTransformType.Steam:
+                    return new OtpTransformSteam();
+                case OtpTransformType.Digits:
+                default:
+                    return new OtpTransformDigits();
+            }
+        }
+    }
+
+    public class OtpTransformDigits : OtpTransform
+    {
+        int digits;
+
+        public override Totp getCustomTotp(OtpAuthData data)
+        {
+            this.digits = data.Digits;
+            return new Totp(data.Key, data.Period, data.Algorithm, data.Digits, null);
+        }
+
+        public override string transformTotp(Totp totp, DateTime timestamp)
+        {
+            return totp.ComputeTotp(timestamp).PadLeft(digits, '0');
+        }
+    }
+
+    public class OtpTransformSteam : OtpTransform
+    {
+        private static readonly char[] STEAMCHARS = new char[] {
+            '2', '3', '4', '5', '6', '7', '8', '9', 'B', 'C',
+            'D', 'F', 'G', 'H', 'J', 'K', 'M', 'N', 'P', 'Q',
+            'R', 'T', 'V', 'W', 'X', 'Y'
+        };
+        public override Totp getCustomTotp(OtpAuthData data)
+        {
+            return new Totp(data.Key, data.Period, data.Algorithm, int.MaxValue.ToString().Length, null);
+        }
+
+        public override string transformTotp(Totp totp, DateTime timestamp)
+        {
+            string code = totp.ComputeTotp(timestamp);
+            long.TryParse(code, out long codeNum);
+
+            StringBuilder sb = new StringBuilder();
+
+            for (int i = 0; i < 5; i++)
+            {
+                sb.Append(STEAMCHARS[codeNum % STEAMCHARS.Length]);
+                codeNum /= STEAMCHARS.Length;
+            }
+
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a mechanism to add transforms (in code) to the TOTP. The transform can:

a) Override the inputs to the creation of the OtpSharp's Totp object and,
b) Transform / Encode the output TOTP code

Both are sometimes required to output proprietary / obscure TOTP codes. 

In this commit, I have added a wrapper to OtpSharp's Totp called OtpTotp. This object is an attempt to clean up the multiple places in code where the Totp object is used in different ways. There is now a centralized place to get the TOTP string -- new OtpTotp(data).getTotpString(timestamp)

I have included a "null" transformer, called Digits. This transformer just pads out the TOTP code with zeros ('0') to the number of digits of the TOTP. I've removed places in code where this is duplicated. This is the default transform.

The other transformer I have included is for Steam Guard. Steam uses a RFC6238 TOTP, but encodes the output into a 5-digit alphanumeric TOTP. The algorithm for this transform has been reverse engineered and scattered around the web.

